### PR TITLE
Fix JavaScript

### DIFF
--- a/JavaScript.js
+++ b/JavaScript.js
@@ -1,7 +1,7 @@
-var j = 0;
+var j = 0n;
 
-for (i = 1; i <= 1000000000; i++) {
+for (i = 1n; i <= 1000000000n; i++) {
    j += i;
 }
 
-console.log(j);
+console.log(j.toString());

--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 Calculating the **sum** from one to a billion in different programming languages, inspired by [@leachim6/hello-world](https://github.com/leachim6/hello-world)
 
 The following implementations need to be reviewed:
-+ [JavaScript](JavaScript.js)
 + [Mathematica](Mathematica.m)
 
 ## Current Languages


### PR DESCRIPTION
The new code uses BigInt instead of regular numbers, to avoid loss of precision.