### PR TITLE
Add TypeScript

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,3 +37,4 @@ The following implementation(s) need to be reviewed:
 - [SML](SML.sml)
 - [Smalltalk](Smalltalk.st)
 - [Swift](Swift.swift)
+- [TypeScript](TypeScript.ts)

--- a/TypeScript.ts
+++ b/TypeScript.ts
@@ -1,0 +1,7 @@
+var j = 0n;
+
+for (var i = 1n; i <= 1000000000n; i++) {
+   j += i;
+}
+
+console.log(j.toString());


### PR DESCRIPTION
Note: If you compile the TypeScript, you need to set the `compilerOptions` `target` property to `"esnext"`. So, something like this: 

```
{
  "compilerOptions": {
    "target": "esnext",
    "lib": ["esnext", "dom"],
    "module": "commonjs",
    "moduleResolution": "node",
    "strict": true,
    "jsx": "react",
    "allowJs": true,
    "sourceMap": true,
    "inlineSources": true,
    "types": ["node"],
    "allowSyntheticDefaultImports": true,
    "experimentalDecorators": true
  }
}
```